### PR TITLE
Adds argument validation for New and FromString

### DIFF
--- a/typeid.go
+++ b/typeid.go
@@ -81,6 +81,9 @@ func From(prefix string, suffix string) (TypeID, error) {
 
 func FromString(s string) (TypeID, error) {
 	parts := strings.SplitN(s, "_", 2)
+	if len(parts) < 2 {
+		return Nil, fmt.Errorf("invalid typeid: %s", s)
+	}
 	return From(parts[0], parts[1])
 }
 
@@ -106,6 +109,9 @@ func Must(tid TypeID, err error) TypeID {
 }
 
 func validatePrefix(prefix string) error {
+	if len(prefix) == 0 {
+		return fmt.Errorf("invalid prefix: '%s'. Prefix should match [a-z]+", prefix)
+	}
 	// Ensure that the prefix only has lowercase ASCII characters
 	for _, c := range prefix {
 		if c < 'a' || c > 'z' {


### PR DESCRIPTION
These validations were found by running:

```go
func TestFromString(t *testing.T) {
	id, err := New(prefix)
	if err != nil {
		t.Fatal(err)
	}
	str := id.String()
	id2, err := FromString(str)
	if err != nil {
		t.Fatal(err)
	}
	if id != id2 {
		t.Fatalf("Expected %v, got %v", id, id2)
	}
}
```

For different values of `prefix` using [go fuzz](https://go.dev/doc/tutorial/fuzz).

My assumption was that it was a nice property that `typeid`s should have: you should be able to create one, get it's string representation and then rebuild it with `FromString`. 

The bugs encountered were:

* `validatePrefix` does not check `prefix` length so it's not enforcing `[a-z]+` as the error message says, but `[a-z]*` which may not be intended
* `FromString` assumes a properly formatted string or else panics. This should not be the case because (a) since the method signature returns an `error`, that should be the way to indicate the argument is incorrect and (b) we can get to an invalid string argument by running `New("")` as described in the previous bullet.